### PR TITLE
Re-run failed jobs only

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This action allows re-running a workflow when labels are added to (or removed fr
 | `once-label` | no\* | When this label is added to a pull request, re-run the `workflow` once and remove the label again. |
 | `continuous-label` | no\* | When this label is added to a pull request, continuously re-run the `workflow` until it succeeds or is cancelled. The action needs to be run on `workflow_run`, `push` or `schedule` events for this to work. |
 | `trigger-labels` | no\* | When any of the labels in this comma-separated list is added to or removed from a pull request, re-run the `workflow` once. |
+| `failed-jobs-only`| no | Specify whether only failed jobs should be re-run |
 | `workflow` | yes | File name or ID of the workflow which should be re-run. |
 
 \* At least one of `once-label`, `continuous-label` or `trigger-labels` is required.

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
       When any of the labels in this comma-separated list is added to or
       removed from a pull request, re-run the `workflow` once.
     required: false
+  failed-jobs-only:
+    description: >
+      When re-running the workflow, only re-run jobs which have failed.
+    required: false
   workflow:
     description: File name or ID of the workflow which should be re-run.
     required: true

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -130,7 +130,7 @@ export async function rerunFailedJobs(octokit: Octokit, workflowRun: WorkflowRun
     await octokit.rest.actions.reRunWorkflowFailedJobs({
       ...github.context.repo,
       run_id: workflowRun.id,
-    })s
+    })
     core.info(`Re-run of failed jobs in workflow run ${workflowRun.id} successfully started.`)
   } catch (err) {
     core.setFailed(`Re-running failed jobs in workflow run ${workflowRun.id} failed: ${err}`)

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -118,6 +118,25 @@ export async function rerunWorkflow(octokit: Octokit, workflowRun: WorkflowRun):
   }
 }
 
+export async function rerunFailedJobs(octokit: Octokit, workflowRun: WorkflowRun): Promise<void> {
+  try {
+    core.info(`Triggering re-run of failed jobs for workflow run ${workflowRun.id}…`)
+
+    if (!isPresent(workflowRun.check_suite_id)) {
+      core.setFailed(`No check suite ID defined for workflow run ${workflowRun.id}.`)
+      return
+    }
+
+    await octokit.rest.actions.reRunWorkflowFailedJobs({
+      ...github.context.repo,
+      run_id: workflowRun.id,
+    })s
+    core.info(`Re-run of failed jobs in workflow run ${workflowRun.id} successfully started.`)
+  } catch (err) {
+    core.setFailed(`Re-running failed jobs in workflow run ${workflowRun.id} failed: ${err}`)
+  }
+}
+
 export async function removeLabelFromPullRequest(
   octokit: Octokit,
   pullRequest: PullRequest,

--- a/src/input.ts
+++ b/src/input.ts
@@ -6,6 +6,7 @@ export interface Input {
   continuousLabel: string | null
   triggerLabels: string[]
   workflow: string
+  failedJobsOnly: boolean
 }
 
 export function get(): Input {
@@ -13,6 +14,7 @@ export function get(): Input {
   const onceLabel = core.getInput('once-label') || null
   const continuousLabel = core.getInput('continuous-label') || null
   let triggerLabels = core.getInput('trigger-labels').split(',')
+  const failedJobsOnly = core.getInput('failed-jobs-only') === 'true' || false
   const workflow = core.getInput('workflow', { required: true })
 
   if (!onceLabel && !continuousLabel && !triggerLabels) {
@@ -33,5 +35,5 @@ export function get(): Input {
     triggerLabels = triggerLabels.filter(l => l !== continuousLabel)
   }
 
-  return { token, onceLabel, continuousLabel, triggerLabels, workflow }
+  return { token, onceLabel, continuousLabel, triggerLabels,  failedJobsOnly, workflow }
 }

--- a/src/input.ts
+++ b/src/input.ts
@@ -14,7 +14,7 @@ export function get(): Input {
   const onceLabel = core.getInput('once-label') || null
   const continuousLabel = core.getInput('continuous-label') || null
   let triggerLabels = core.getInput('trigger-labels').split(',')
-  const failedJobsOnly = core.getInput('failed-jobs-only') === 'true' || false
+  const failedJobsOnly = core.getInput('failed-jobs-only') === 'true'
   const workflow = core.getInput('workflow', { required: true })
 
   if (!onceLabel && !continuousLabel && !triggerLabels) {


### PR DESCRIPTION
This is an initial pass at a change that would allow the re-running of only failed jobs, rather than the entire suite.
Could be useful where there is flaky network-related failures, particularly when flaky test failures relate to something outside of the scope of the repo.

It may be better to have a separate label condition that runs the job instead (much like the continuous label), rather than setting at a per-action level.